### PR TITLE
save assistant messages as EventNewAssistantMessage instead of EventNewToken

### DIFF
--- a/chat/chat.go
+++ b/chat/chat.go
@@ -169,7 +169,7 @@ func (c *Chat) Session(ctx context.Context, client Client) <-chan StreamEvent {
 func (c *Chat) handleCompletionEnd(ctx context.Context, state *sessionState) (proceed bool) {
 	// adding collected events to the chat (assistant's tokens and tool calls)
 	if state.builder.Len() != 0 {
-		c.AppendEvent(NewEventNewToken(state.builder.String()))
+		c.AppendEvent(NewEventNewAssistantMessage(state.builder.String()))
 	}
 	for _, call := range state.toolCalls {
 		c.AppendEvent(call)

--- a/chat/chat_test.go
+++ b/chat/chat_test.go
@@ -418,9 +418,9 @@ func TestSession_CollectsTokens(t *testing.T) {
 	var tokenCount int
 	var tokenContent string
 	for _, msg := range messages {
-		if msg.GetType() == eventNewToken {
+		if msg.GetType() == eventNewAssistantMessage {
 			tokenCount++
-			tokenContent = msg.(EventNewToken).Content
+			tokenContent = msg.(EventNewAssistantMessage).Content
 		}
 	}
 

--- a/chat/helpers.go
+++ b/chat/helpers.go
@@ -23,6 +23,11 @@ func (c *Chat) AddMessage(sender Sender, content string) error {
 	return nil
 }
 
+// AppendEvent adds a full message event to the chat.
+// The event must represent a complete message (e.g., EventNewUserMessage,
+// EventNewAssistantMessage, EventNewToolMessage), not intermediate streaming
+// events like EventNewToken. Providers are not required to sync such events
+// in their SyncInput implementation.
 func (c *Chat) AppendEvent(event StreamEvent) {
 	c.Messages.AddEvent(event)
 }

--- a/chat/types.go
+++ b/chat/types.go
@@ -17,7 +17,17 @@ type Chat struct {
 type Client interface {
 	// NewStreaming returns a new streaming client instance
 	NewStreaming(ctx context.Context) Stream[StreamEvent]
-	// SyncInput return a copy of the client with updated input configuration (messages, tools, etc.)
+	// SyncInput returns a new client instance with input configuration synchronized from the chat.
+	//
+	// Contract:
+	//   - Must return a new client instance (original client must remain unchanged)
+	//   - Must synchronize all complete message events from chat.Messages to client params
+	//   - Must synchronize tools from chat.Tools to client params
+	//   - Must preserve client-specific settings (model, API key, endpoint, etc.)
+	//   - Should NOT synchronize streaming-only events (e.g., EventNewToken, EventCompletionEnded)
+	//     - Only full message events should be converted: EventNewUserMessage,
+	//       EventNewAssistantMessage, EventNewSystemMessage, EventNewToolMessage,
+	//       EventNewToolCall, EventNewRefusal
 	SyncInput(chat *Chat) Client
 }
 


### PR DESCRIPTION
> "Minor version numbers are for when you're ashamed of the changes."

## Summary

`Session` was appending the collected assistant response to chat history as `NewEventNewToken` instead of `NewEventNewAssistantMessage`. Since the `SyncInput` contract explicitly states that streaming-only events (including `EventNewToken`) should not be synced to client params, providers were silently dropping the assistant's turns — making the model appear to have no memory of its own responses.

## Changes

- `handleCompletionEnd` now appends `NewEventNewAssistantMessage` instead of `NewEventNewToken`
- `SyncInput` and `AppendEvent` contracts documented explicitly in `types.go` and `helpers.go`
- Test `TestSession_CollectsTokens` updated to assert on `EventNewAssistantMessage`

Closes #26