### PR TITLE
fix: initialize nil Messages and Tools in Chat via ensureDefaults

### DIFF
--- a/chat/chat.go
+++ b/chat/chat.go
@@ -3,6 +3,8 @@ package chat
 import (
 	"context"
 	"strings"
+
+	"github.com/x2d7/interlude/chat/tools"
 )
 
 func (c *Chat) Complete(ctx context.Context, client Client) <-chan StreamEvent {
@@ -69,7 +71,20 @@ func (s *sessionState) flushLastToolCall() bool {
 	return ok
 }
 
+func (c *Chat) ensureDefaults() {
+	if c.Messages == nil {
+		c.Messages = NewMessages()
+	}
+	if c.Tools == nil {
+		t := tools.NewTools()
+		c.Tools = &t
+	}
+}
+
 func (c *Chat) Session(ctx context.Context, client Client) <-chan StreamEvent {
+	// ensuring default values
+	c.ensureDefaults()
+
 	// insert chat context into client input configuration
 	client = client.SyncInput(c)
 


### PR DESCRIPTION
Closes #30

## Summary
`Chat` struct allows partial initialization — omitting `Messages` or `Tools` is valid Go, but caused a nil pointer panic on the first call to `Session`. Since the zero value of a struct should be as useful as possible, the fix initializes missing fields lazily at the entry point rather than forcing callers to provide them.

## Changes
`ensureDefaults()` added to `chat.go`, called at the top of `Session()`
Unit tests covering nil `Messages`, nil `Tools`, both nil, and preservation of existing values