### PR TITLE
make NewTools return *Tools for consistency with NewMessages

### DIFF
--- a/chat/chat_test.go
+++ b/chat/chat_test.go
@@ -350,7 +350,7 @@ func TestSyncInput_WithNewTools(t *testing.T) {
 	chatTools := tools.NewTools()
 	chat := &Chat{
 		Messages: NewMessages(),
-		Tools:    &chatTools,
+		Tools:    chatTools,
 	}
 	// Add a tool using NewTool
 	tool, err := tools.NewTool("test-tool", "Test tool",
@@ -551,7 +551,7 @@ func TestSession_ToolAccepted(t *testing.T) {
 	chatTools := tools.NewTools()
 	chat := &Chat{
 		Messages: NewMessages(),
-		Tools:    &chatTools,
+		Tools:    chatTools,
 	}
 
 	// Add a test tool
@@ -608,7 +608,7 @@ func TestSession_ToolRejected(t *testing.T) {
 	chatTools := tools.NewTools()
 	chat := &Chat{
 		Messages: NewMessages(),
-		Tools:    &chatTools,
+		Tools:    chatTools,
 	}
 
 	tool, err := tools.NewTool[map[string]string]("test-tool", "Test tool",
@@ -665,7 +665,7 @@ func TestSession_NonExistentTool(t *testing.T) {
 	chatTools := tools.NewTools()
 	chat := &Chat{
 		Messages: NewMessages(),
-		Tools:    &chatTools,
+		Tools:    chatTools,
 	}
 
 	// Round 1: tool call, Round 2: empty to finish (Session generates CompletionEnded)
@@ -949,7 +949,7 @@ func TestSession_ContextCancelledWhileWaitingForApproval(t *testing.T) {
 	chatTools := tools.NewTools()
 	chat := &Chat{
 		Messages: NewMessages(),
-		Tools:    &chatTools,
+		Tools:    chatTools,
 	}
 
 	tool, err := tools.NewTool[map[string]string]("test-tool", "Test tool",
@@ -1006,7 +1006,7 @@ func TestSession_ContextCancelledBetweenRounds(t *testing.T) {
 	chatTools := tools.NewTools()
 	chat := &Chat{
 		Messages: NewMessages(),
-		Tools:    &chatTools,
+		Tools:    chatTools,
 	}
 
 	tool, err := tools.NewTool[map[string]string]("test-tool", "Test tool",
@@ -1062,7 +1062,7 @@ func TestSession_ToolCallAssembly_Basic(t *testing.T) {
 	chatTools := tools.NewTools()
 	chat := &Chat{
 		Messages: NewMessages(),
-		Tools:    &chatTools,
+		Tools:    chatTools,
 	}
 
 	tool, err := tools.NewTool[map[string]string]("weather", "Get weather",
@@ -1128,7 +1128,7 @@ func TestSession_ToolCallAssembly_MultipleToolsWithAssembly(t *testing.T) {
 	chatTools := tools.NewTools()
 	chat := &Chat{
 		Messages: NewMessages(),
-		Tools:    &chatTools,
+		Tools:    chatTools,
 	}
 
 	tool1, err := tools.NewTool[map[string]string]("tool1", "Tool 1",
@@ -1223,7 +1223,7 @@ func TestSession_ToolCallAssembly_LargeContent(t *testing.T) {
 	chatTools := tools.NewTools()
 	chat := &Chat{
 		Messages: NewMessages(),
-		Tools:    &chatTools,
+		Tools:    chatTools,
 	}
 
 	tool, err := tools.NewTool[map[string]string]("search", "Search",
@@ -1298,7 +1298,7 @@ func TestSession_MixedTokensAndToolCalls(t *testing.T) {
 	chatTools := tools.NewTools()
 	chat := &Chat{
 		Messages: NewMessages(),
-		Tools:    &chatTools,
+		Tools:    chatTools,
 	}
 
 	tool, err := tools.NewTool[map[string]string]("lookup", "Lookup tool",

--- a/chat/tools/types.go
+++ b/chat/tools/types.go
@@ -22,10 +22,12 @@ type Tools struct {
 	tools map[string]tool
 }
 
-func NewTools() Tools {
-	return Tools{
+func NewTools() *Tools {
+	t := Tools{
 		tools: make(map[string]tool),
 	}
+
+	return &t
 }
 
 func (t *Tools) Add(tool tool, opts ...AddOption) error {

--- a/connect/openai/openai_test.go
+++ b/connect/openai/openai_test.go
@@ -257,7 +257,7 @@ func TestOpenAIMessages_Add_Sequence(t *testing.T) {
 
 func TestConvertTools_EmptyTools(t *testing.T) {
 	ts := tools.NewTools()
-	result := ConvertTools(&ts)
+	result := ConvertTools(ts)
 
 	if len(result) != 0 {
 		t.Errorf("Expected empty slice for empty tools, got %d elements", len(result))
@@ -277,7 +277,7 @@ func TestConvertTools_SingleTool(t *testing.T) {
 	}
 	ts.Add(tool)
 
-	result := ConvertTools(&ts)
+	result := ConvertTools(ts)
 
 	if len(result) != 1 {
 		t.Fatalf("Expected 1 tool, got %d", len(result))
@@ -308,7 +308,7 @@ func TestConvertTools_MultipleTools(t *testing.T) {
 		ts.Add(tool)
 	}
 
-	result := ConvertTools(&ts)
+	result := ConvertTools(ts)
 
 	if len(result) != 3 {
 		t.Fatalf("Expected 3 tools, got %d", len(result))
@@ -344,7 +344,7 @@ func TestConvertTools_ParametersIncluded(t *testing.T) {
 	}
 	ts.Add(tool)
 
-	result := ConvertTools(&ts)
+	result := ConvertTools(ts)
 
 	if len(result) != 1 {
 		t.Fatalf("Expected 1 tool, got %d", len(result))
@@ -444,7 +444,7 @@ func TestSyncInput_ToolsAreSynced(t *testing.T) {
 
 	c := &chat.Chat{
 		Messages: chat.NewMessages(),
-		Tools:    &ts,
+		Tools:    ts,
 	}
 
 	result := original.SyncInput(c)


### PR DESCRIPTION
## Summary

`NewMessages()` returns `*Messages`, but `NewTools()` returned `Tools` by value — forcing callers to take the address manually with `&toolList`. 
Since both types contain a mutex internally, returning by pointer is also the correct choice to prevent accidental copies.

## Changes

- `NewTools()` now returns `*Tools` instead of `Tools`
- All test setup updated to remove manual `&` dereference

```go
// before
toolList := tools.NewTools()
c := chat.Chat{Tools: &toolList}

// after
c := chat.Chat{Tools: tools.NewTools()}
```