### PR TITLE
release v0.3.0: Chat zero-value safety and consistent constructors

### DIFF
--- a/chat/chat.go
+++ b/chat/chat.go
@@ -77,7 +77,7 @@ func (c *Chat) ensureDefaults() {
 	}
 	if c.Tools == nil {
 		t := tools.NewTools()
-		c.Tools = &t
+		c.Tools = t
 	}
 }
 

--- a/chat/chat.go
+++ b/chat/chat.go
@@ -3,6 +3,8 @@ package chat
 import (
 	"context"
 	"strings"
+
+	"github.com/x2d7/interlude/chat/tools"
 )
 
 func (c *Chat) Complete(ctx context.Context, client Client) <-chan StreamEvent {
@@ -69,7 +71,20 @@ func (s *sessionState) flushLastToolCall() bool {
 	return ok
 }
 
+func (c *Chat) ensureDefaults() {
+	if c.Messages == nil {
+		c.Messages = NewMessages()
+	}
+	if c.Tools == nil {
+		t := tools.NewTools()
+		c.Tools = &t
+	}
+}
+
 func (c *Chat) Session(ctx context.Context, client Client) <-chan StreamEvent {
+	// ensuring default values
+	c.ensureDefaults()
+
 	// insert chat context into client input configuration
 	client = client.SyncInput(c)
 

--- a/chat/chat_test.go
+++ b/chat/chat_test.go
@@ -350,7 +350,7 @@ func TestSyncInput_WithNewTools(t *testing.T) {
 	chatTools := tools.NewTools()
 	chat := &Chat{
 		Messages: NewMessages(),
-		Tools:    &chatTools,
+		Tools:    chatTools,
 	}
 	// Add a tool using NewTool
 	tool, err := tools.NewTool("test-tool", "Test tool",
@@ -551,7 +551,7 @@ func TestSession_ToolAccepted(t *testing.T) {
 	chatTools := tools.NewTools()
 	chat := &Chat{
 		Messages: NewMessages(),
-		Tools:    &chatTools,
+		Tools:    chatTools,
 	}
 
 	// Add a test tool
@@ -608,7 +608,7 @@ func TestSession_ToolRejected(t *testing.T) {
 	chatTools := tools.NewTools()
 	chat := &Chat{
 		Messages: NewMessages(),
-		Tools:    &chatTools,
+		Tools:    chatTools,
 	}
 
 	tool, err := tools.NewTool[map[string]string]("test-tool", "Test tool",
@@ -665,7 +665,7 @@ func TestSession_NonExistentTool(t *testing.T) {
 	chatTools := tools.NewTools()
 	chat := &Chat{
 		Messages: NewMessages(),
-		Tools:    &chatTools,
+		Tools:    chatTools,
 	}
 
 	// Round 1: tool call, Round 2: empty to finish (Session generates CompletionEnded)
@@ -949,7 +949,7 @@ func TestSession_ContextCancelledWhileWaitingForApproval(t *testing.T) {
 	chatTools := tools.NewTools()
 	chat := &Chat{
 		Messages: NewMessages(),
-		Tools:    &chatTools,
+		Tools:    chatTools,
 	}
 
 	tool, err := tools.NewTool[map[string]string]("test-tool", "Test tool",
@@ -1006,7 +1006,7 @@ func TestSession_ContextCancelledBetweenRounds(t *testing.T) {
 	chatTools := tools.NewTools()
 	chat := &Chat{
 		Messages: NewMessages(),
-		Tools:    &chatTools,
+		Tools:    chatTools,
 	}
 
 	tool, err := tools.NewTool[map[string]string]("test-tool", "Test tool",
@@ -1062,7 +1062,7 @@ func TestSession_ToolCallAssembly_Basic(t *testing.T) {
 	chatTools := tools.NewTools()
 	chat := &Chat{
 		Messages: NewMessages(),
-		Tools:    &chatTools,
+		Tools:    chatTools,
 	}
 
 	tool, err := tools.NewTool[map[string]string]("weather", "Get weather",
@@ -1128,7 +1128,7 @@ func TestSession_ToolCallAssembly_MultipleToolsWithAssembly(t *testing.T) {
 	chatTools := tools.NewTools()
 	chat := &Chat{
 		Messages: NewMessages(),
-		Tools:    &chatTools,
+		Tools:    chatTools,
 	}
 
 	tool1, err := tools.NewTool[map[string]string]("tool1", "Tool 1",
@@ -1223,7 +1223,7 @@ func TestSession_ToolCallAssembly_LargeContent(t *testing.T) {
 	chatTools := tools.NewTools()
 	chat := &Chat{
 		Messages: NewMessages(),
-		Tools:    &chatTools,
+		Tools:    chatTools,
 	}
 
 	tool, err := tools.NewTool[map[string]string]("search", "Search",
@@ -1298,7 +1298,7 @@ func TestSession_MixedTokensAndToolCalls(t *testing.T) {
 	chatTools := tools.NewTools()
 	chat := &Chat{
 		Messages: NewMessages(),
-		Tools:    &chatTools,
+		Tools:    chatTools,
 	}
 
 	tool, err := tools.NewTool[map[string]string]("lookup", "Lookup tool",

--- a/chat/chat_test.go
+++ b/chat/chat_test.go
@@ -1424,7 +1424,7 @@ func TestEnsureDefaults_MessagesNil(t *testing.T) {
 	tools := tools.NewTools()
 	chat := &Chat{
 		Messages: nil,
-		Tools:    &tools,
+		Tools:    tools,
 	}
 
 	chat.ensureDefaults()
@@ -1484,7 +1484,7 @@ func TestEnsureDefaults_AlreadySet(t *testing.T) {
 	ts := tools.NewTools()
 	chat := &Chat{
 		Messages: NewMessages(),
-		Tools:    &ts, // Use NewTools() to properly initialize
+		Tools:    ts, // Use NewTools() to properly initialize
 	}
 
 	// Add some data

--- a/chat/tools/types.go
+++ b/chat/tools/types.go
@@ -22,10 +22,12 @@ type Tools struct {
 	tools map[string]tool
 }
 
-func NewTools() Tools {
-	return Tools{
+func NewTools() *Tools {
+	t := Tools{
 		tools: make(map[string]tool),
 	}
+
+	return &t
 }
 
 func (t *Tools) Add(tool tool, opts ...AddOption) error {

--- a/connect/openai/openai_test.go
+++ b/connect/openai/openai_test.go
@@ -257,7 +257,7 @@ func TestOpenAIMessages_Add_Sequence(t *testing.T) {
 
 func TestConvertTools_EmptyTools(t *testing.T) {
 	ts := tools.NewTools()
-	result := ConvertTools(&ts)
+	result := ConvertTools(ts)
 
 	if len(result) != 0 {
 		t.Errorf("Expected empty slice for empty tools, got %d elements", len(result))
@@ -277,7 +277,7 @@ func TestConvertTools_SingleTool(t *testing.T) {
 	}
 	ts.Add(tool)
 
-	result := ConvertTools(&ts)
+	result := ConvertTools(ts)
 
 	if len(result) != 1 {
 		t.Fatalf("Expected 1 tool, got %d", len(result))
@@ -308,7 +308,7 @@ func TestConvertTools_MultipleTools(t *testing.T) {
 		ts.Add(tool)
 	}
 
-	result := ConvertTools(&ts)
+	result := ConvertTools(ts)
 
 	if len(result) != 3 {
 		t.Fatalf("Expected 3 tools, got %d", len(result))
@@ -344,7 +344,7 @@ func TestConvertTools_ParametersIncluded(t *testing.T) {
 	}
 	ts.Add(tool)
 
-	result := ConvertTools(&ts)
+	result := ConvertTools(ts)
 
 	if len(result) != 1 {
 		t.Fatalf("Expected 1 tool, got %d", len(result))
@@ -444,7 +444,7 @@ func TestSyncInput_ToolsAreSynced(t *testing.T) {
 
 	c := &chat.Chat{
 		Messages: chat.NewMessages(),
-		Tools:    &ts,
+		Tools:    ts,
 	}
 
 	result := original.SyncInput(c)


### PR DESCRIPTION
## Summary

Two related improvements to `Chat` initialization and API consistency.

### Fix: Chat panics without Tools field (#30)

`Chat{}` without `Tools` caused a nil pointer panic on the first `Session()` call.
`ensureDefaults()` now initializes missing `Messages` and `Tools` lazily at the entry point — existing values are never overwritten.

### Refactor: consistent constructors

`NewTools()` previously returned `Tools` by value, while `NewMessages()` returned `*Messages` — forcing callers to manually take `&toolList`. Both types contain a mutex internally, so returning by pointer is correct regardless. Now both constructors return a pointer.
```go
// before
toolList := tools.NewTools()
c := chat.Chat{Tools: &toolList}

// after
c := chat.Chat{Tools: tools.NewTools()}
```

Closes #30