### PR TITLE
Stream events: completion lifecycle, tool call streaming and resolution

### DIFF
--- a/chat/chat.go
+++ b/chat/chat.go
@@ -200,6 +200,7 @@ func (c *Chat) Session(ctx context.Context, client Client) <-chan StreamEvent {
 }
 
 func (c *Chat) handleCompletionEnd(ctx context.Context, state *sessionState) (proceed bool) {
+	proceed = false
 	// adding collected events to the chat (assistant's tokens and tool calls)
 	if state.builder.Len() != 0 {
 		c.AppendEvent(NewEventAssistantMessage(state.builder.String()))
@@ -212,16 +213,16 @@ func (c *Chat) handleCompletionEnd(ctx context.Context, state *sessionState) (pr
 
 	// send last tool call if it wasn't sent yet
 	if !state.flushLastToolCall() {
-		return false
+		return
 	}
 
 	// ending current completion
 	if !state.send(NewEventCompletionEnded()) {
-		return false
+		return
 	}
 
 	if callAmount == 0 {
-		return false
+		return
 	}
 
 	// initializing approval waiter

--- a/chat/chat.go
+++ b/chat/chat.go
@@ -240,7 +240,7 @@ func (c *Chat) handleCompletionEnd(ctx context.Context, state *sessionState) (pr
 	}
 
 	// ending current completion
-	if !state.send(NewEventCompletionEnded()) {
+	if !state.send(NewEventCompletionEnded(state.toolCalls)) {
 		return
 	}
 

--- a/chat/chat.go
+++ b/chat/chat.go
@@ -172,6 +172,15 @@ func (c *Chat) Session(ctx context.Context, client Client) <-chan StreamEvent {
 						if !state.flushLastToolCall() {
 							return
 						}
+
+						// inject callback
+						event.onResolved = func(callID string, accepted bool) {
+							send(EventToolCallResolved{
+								CallID:   callID,
+								Accepted: accepted,
+							})
+						}
+
 						state.approval.Attach(&event)
 						state.toolCalls = append(state.toolCalls, event)
 						state.lastToolCall = &state.toolCalls[len(state.toolCalls)-1]

--- a/chat/chat.go
+++ b/chat/chat.go
@@ -121,6 +121,11 @@ func (c *Chat) Session(ctx context.Context, client Client) <-chan StreamEvent {
 
 		for {
 			if restart {
+				// send completion start event
+				if !send(NewEventCompletionStart()) {
+					return
+				}
+
 				// reset state
 				state.reset()
 

--- a/chat/chat.go
+++ b/chat/chat.go
@@ -255,11 +255,20 @@ func (c *Chat) handleCompletionEnd(ctx context.Context, state *sessionState) (pr
 	for verdict := range verdicts {
 		call := verdict.call
 
+		var toolMessage EventToolMessage
+
 		if verdict.Accepted {
 			callResult, success := c.Tools.Execute(call.Name, call.Content)
-			c.AppendEvent(NewEventToolMessage(call.CallID, callResult, success))
+			toolMessage = NewEventToolMessage(call.CallID, callResult, success)
 		} else {
-			c.AppendEvent(NewEventToolMessage(call.CallID, "User declined the tool call", false))
+			toolMessage = NewEventToolMessage(call.CallID, "User declined the tool call", false)
+		}
+		// adding tool message to the chat
+		c.AppendEvent(toolMessage)
+
+		// sending tool message
+		if !state.send(toolMessage) {
+			return
 		}
 	}
 

--- a/chat/chat.go
+++ b/chat/chat.go
@@ -175,9 +175,23 @@ func (c *Chat) Session(ctx context.Context, client Client) <-chan StreamEvent {
 						state.approval.Attach(&event)
 						state.toolCalls = append(state.toolCalls, event)
 						state.lastToolCall = &state.toolCalls[len(state.toolCalls)-1]
+
+						// send tool call token
+						if !state.send(NewEventToolCallToken(event.CallID, event.Name, event.Content)) {
+							return
+						}
 					} else {
 						// add token to the last tool call
 						state.lastToolCall.Content += event.Content
+
+						callID := state.lastToolCall.CallID
+						name := state.lastToolCall.Name
+						token := event.Content
+
+						// send tool call token
+						if !state.send(NewEventToolCallToken(callID, name, token)) {
+							return
+						}
 					}
 				case EventRefusal:
 					c.AppendEvent(event)

--- a/chat/chat.go
+++ b/chat/chat.go
@@ -117,10 +117,10 @@ func (c *Chat) Session(ctx context.Context, client Client) <-chan StreamEvent {
 		}
 
 		// flag to start completion this iteration
-		doStartCompletion := true
+		restart := true
 
 		for {
-			if doStartCompletion {
+			if restart {
 				// reset state
 				state.reset()
 
@@ -130,7 +130,7 @@ func (c *Chat) Session(ctx context.Context, client Client) <-chan StreamEvent {
 
 				// start completion
 				state.events = c.Complete(ctx, client)
-				doStartCompletion = false
+				restart = false
 			}
 
 			select {
@@ -141,7 +141,7 @@ func (c *Chat) Session(ctx context.Context, client Client) <-chan StreamEvent {
 					if !c.handleCompletionEnd(ctx, state) {
 						return
 					}
-					doStartCompletion = true
+					restart = true
 					continue
 				}
 

--- a/chat/chat.go
+++ b/chat/chat.go
@@ -86,9 +86,6 @@ func (c *Chat) Session(ctx context.Context, client Client) <-chan StreamEvent {
 	// ensuring default values
 	c.ensureDefaults()
 
-	// insert chat context into client input configuration
-	client = client.SyncInput(c)
-
 	// creating the channels
 	result := make(chan StreamEvent, 16)
 
@@ -115,14 +112,27 @@ func (c *Chat) Session(ctx context.Context, client Client) <-chan StreamEvent {
 
 		// session state
 		state := &sessionState{
-			client: client,
-			events: c.Complete(ctx, client),
-			send:   send,
-			ctx:    ctx,
+			send: send,
+			ctx:  ctx,
 		}
-		state.reset()
+
+		// flag to start completion this iteration
+		doStartCompletion := true
 
 		for {
+			if doStartCompletion {
+				// reset state
+				state.reset()
+
+				// insert chat context into client input configuration
+				client := client.SyncInput(c)
+				state.client = client
+
+				// start completion
+				state.events = c.Complete(ctx, client)
+				doStartCompletion = false
+			}
+
 			select {
 			case <-ctx.Done():
 				return
@@ -131,6 +141,7 @@ func (c *Chat) Session(ctx context.Context, client Client) <-chan StreamEvent {
 					if !c.handleCompletionEnd(ctx, state) {
 						return
 					}
+					doStartCompletion = true
 					continue
 				}
 
@@ -222,13 +233,6 @@ func (c *Chat) handleCompletionEnd(ctx context.Context, state *sessionState) (pr
 			c.AppendEvent(NewEventToolMessage(call.CallID, "User declined the tool call", false))
 		}
 	}
-
-	// reset state
-	state.reset()
-
-	// resume text completion
-	state.client = state.client.SyncInput(c)
-	state.events = c.Complete(ctx, state.client)
 
 	return true
 }

--- a/chat/chat_test.go
+++ b/chat/chat_test.go
@@ -780,7 +780,6 @@ func TestHelpers_SendUserStream(t *testing.T) {
 
 	mockClient := NewMockClient()
 	mockClient.SetStreamingEvents([]StreamEvent{
-		NewEventCompletionEnded(),
 	})
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -812,7 +811,6 @@ func TestHelpers_SendAssistantStream(t *testing.T) {
 
 	mockClient := NewMockClient()
 	mockClient.SetStreamingEvents([]StreamEvent{
-		NewEventCompletionEnded(),
 	})
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -844,7 +842,6 @@ func TestHelpers_SendSystemStream(t *testing.T) {
 
 	mockClient := NewMockClient()
 	mockClient.SetStreamingEvents([]StreamEvent{
-		NewEventCompletionEnded(),
 	})
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/chat/chat_test.go
+++ b/chat/chat_test.go
@@ -1522,3 +1522,586 @@ func TestEnsureDefaults_AlreadySet(t *testing.T) {
 		t.Errorf("Expected 1 tool, got %d", len(toolList))
 	}
 }
+
+// ==================== Tool Message Emission Tests ====================
+
+// TestSession_ToolMessageEmission_Success tests that EventToolMessage is emitted when tool call is accepted and succeeds
+func TestSession_ToolMessageEmission_Success(t *testing.T) {
+	chatTools := tools.NewTools()
+	chat := &Chat{
+		Messages: NewMessages(),
+		Tools:    chatTools,
+	}
+
+	tool, err := tools.NewTool[map[string]string]("weather", "Get weather",
+		func(input map[string]string) (string, error) {
+			return "sunny in Moscow", nil
+		})
+	if err != nil {
+		t.Fatalf("Failed to create tool: %v", err)
+	}
+	chat.Tools.Add(tool)
+
+	// Round 1: tool call (Session generates CompletionEnded internally)
+	mockClient := NewMultiRoundMockClient([][]StreamEvent{
+		{NewEventToolCall("call-1", "weather", `{"city": "Moscow"}`)},
+		// Round 2: empty (session exits cleanly)
+		{},
+	})
+
+	ctx := context.Background()
+	events := chat.Session(ctx, mockClient)
+
+	var receivedEvents []StreamEvent
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for event := range events {
+			receivedEvents = append(receivedEvents, event)
+			if tc, ok := event.(EventToolCall); ok {
+				tc.Resolve(true)
+			}
+		}
+	}()
+
+	<-done
+
+	// Verify EventToolMessage was emitted
+	var toolMessageFound bool
+	var toolMessage EventToolMessage
+	for _, event := range receivedEvents {
+		if tm, ok := event.(EventToolMessage); ok {
+			toolMessageFound = true
+			toolMessage = tm
+			break
+		}
+	}
+
+	if !toolMessageFound {
+		t.Error("Expected EventToolMessage to be emitted")
+	}
+
+	if toolMessage.CallID != "call-1" {
+		t.Errorf("Expected CallID 'call-1', got '%s'", toolMessage.CallID)
+	}
+
+	if toolMessage.Content != "sunny in Moscow" {
+		t.Errorf("Expected content 'sunny in Moscow', got '%s'", toolMessage.Content)
+	}
+
+	if !toolMessage.Success {
+		t.Error("Expected Success to be true")
+	}
+}
+
+// TestSession_ToolMessageEmission_Rejection tests that EventToolMessage is emitted when tool call is rejected
+func TestSession_ToolMessageEmission_Rejection(t *testing.T) {
+	chatTools := tools.NewTools()
+	chat := &Chat{
+		Messages: NewMessages(),
+		Tools:    chatTools,
+	}
+
+	tool, err := tools.NewTool[map[string]string]("weather", "Get weather",
+		func(input map[string]string) (string, error) {
+			return "sunny", nil
+		})
+	if err != nil {
+		t.Fatalf("Failed to create tool: %v", err)
+	}
+	chat.Tools.Add(tool)
+
+	// Round 1: tool call (Session generates CompletionEnded internally)
+	mockClient := NewMultiRoundMockClient([][]StreamEvent{
+		{NewEventToolCall("call-1", "weather", `{"city": "Moscow"}`)},
+		// Round 2: empty (session exits cleanly)
+		{},
+	})
+
+	ctx := context.Background()
+	events := chat.Session(ctx, mockClient)
+
+	var receivedEvents []StreamEvent
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for event := range events {
+			receivedEvents = append(receivedEvents, event)
+			if tc, ok := event.(EventToolCall); ok {
+				tc.Resolve(false)
+			}
+		}
+	}()
+
+	<-done
+
+	// Verify EventToolMessage was emitted with rejection message
+	var toolMessageFound bool
+	var toolMessage EventToolMessage
+	for _, event := range receivedEvents {
+		if tm, ok := event.(EventToolMessage); ok {
+			toolMessageFound = true
+			toolMessage = tm
+			break
+		}
+	}
+
+	if !toolMessageFound {
+		t.Error("Expected EventToolMessage to be emitted")
+	}
+
+	if toolMessage.CallID != "call-1" {
+		t.Errorf("Expected CallID 'call-1', got '%s'", toolMessage.CallID)
+	}
+
+	if toolMessage.Content != "User declined the tool call" {
+		t.Errorf("Expected rejection message, got '%s'", toolMessage.Content)
+	}
+
+	if toolMessage.Success {
+		t.Error("Expected Success to be false for rejected tool call")
+	}
+}
+
+// TestSession_ToolMessageEmission_ExecutionError tests that EventToolMessage is emitted when tool execution fails
+func TestSession_ToolMessageEmission_ExecutionError(t *testing.T) {
+	chatTools := tools.NewTools()
+	chat := &Chat{
+		Messages: NewMessages(),
+		Tools:    chatTools,
+	}
+
+	tool, err := tools.NewTool[map[string]string]("failing-tool", "Failing tool",
+		func(input map[string]string) (string, error) {
+			return "", errors.New("tool execution failed")
+		})
+	if err != nil {
+		t.Fatalf("Failed to create tool: %v", err)
+	}
+	chat.Tools.Add(tool)
+
+	// Round 1: tool call (Session generates CompletionEnded internally)
+	mockClient := NewMultiRoundMockClient([][]StreamEvent{
+		{NewEventToolCall("call-1", "failing-tool", `{}`)},
+		// Round 2: empty (session exits cleanly)
+		{},
+	})
+
+	ctx := context.Background()
+	events := chat.Session(ctx, mockClient)
+
+	var receivedEvents []StreamEvent
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for event := range events {
+			receivedEvents = append(receivedEvents, event)
+			if tc, ok := event.(EventToolCall); ok {
+				tc.Resolve(true)
+			}
+		}
+	}()
+
+	<-done
+
+	// Verify EventToolMessage was emitted with error message
+	var toolMessageFound bool
+	var toolMessage EventToolMessage
+	for _, event := range receivedEvents {
+		if tm, ok := event.(EventToolMessage); ok {
+			toolMessageFound = true
+			toolMessage = tm
+			break
+		}
+	}
+
+	if !toolMessageFound {
+		t.Error("Expected EventToolMessage to be emitted")
+	}
+
+	if toolMessage.CallID != "call-1" {
+		t.Errorf("Expected CallID 'call-1', got '%s'", toolMessage.CallID)
+	}
+
+	if !strings.Contains(toolMessage.Content, "tool execution failed") {
+		t.Errorf("Expected error message in content, got '%s'", toolMessage.Content)
+	}
+
+	if toolMessage.Success {
+		t.Error("Expected Success to be false for failed tool execution")
+	}
+}
+
+// TestSession_ToolCallResolvedEvent_Accept tests that EventToolCallResolved is emitted when tool call is accepted
+func TestSession_ToolCallResolvedEvent_Accept(t *testing.T) {
+	chatTools := tools.NewTools()
+	chat := &Chat{
+		Messages: NewMessages(),
+		Tools:    chatTools,
+	}
+
+	tool, err := tools.NewTool[map[string]string]("test-tool", "Test tool",
+		func(input map[string]string) (string, error) {
+			return "result", nil
+		})
+	if err != nil {
+		t.Fatalf("Failed to create tool: %v", err)
+	}
+	chat.Tools.Add(tool)
+
+	// Round 1: tool call (Session generates CompletionEnded internally)
+	mockClient := NewMultiRoundMockClient([][]StreamEvent{
+		{NewEventToolCall("call-1", "test-tool", `{"key": "value"}`)},
+		// Round 2: empty (session exits cleanly)
+		{},
+	})
+
+	ctx := context.Background()
+	events := chat.Session(ctx, mockClient)
+
+	var receivedEvents []StreamEvent
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for event := range events {
+			receivedEvents = append(receivedEvents, event)
+			if tc, ok := event.(EventToolCall); ok {
+				tc.Resolve(true)
+			}
+		}
+	}()
+
+	<-done
+
+	// Verify EventToolCallResolved was emitted
+	var resolvedEventFound bool
+	var resolvedEvent EventToolCallResolved
+	for _, event := range receivedEvents {
+		if r, ok := event.(EventToolCallResolved); ok {
+			resolvedEventFound = true
+			resolvedEvent = r
+			break
+		}
+	}
+
+	if !resolvedEventFound {
+		t.Error("Expected EventToolCallResolved to be emitted")
+	}
+
+	if resolvedEvent.CallID != "call-1" {
+		t.Errorf("Expected CallID 'call-1', got '%s'", resolvedEvent.CallID)
+	}
+
+	if !resolvedEvent.Accepted {
+		t.Error("Expected Accepted to be true")
+	}
+}
+
+// TestSession_ToolCallResolvedEvent_Reject tests that EventToolCallResolved is emitted when tool call is rejected
+func TestSession_ToolCallResolvedEvent_Reject(t *testing.T) {
+	chatTools := tools.NewTools()
+	chat := &Chat{
+		Messages: NewMessages(),
+		Tools:    chatTools,
+	}
+
+	tool, err := tools.NewTool[map[string]string]("test-tool", "Test tool",
+		func(input map[string]string) (string, error) {
+			return "result", nil
+		})
+	if err != nil {
+		t.Fatalf("Failed to create tool: %v", err)
+	}
+	chat.Tools.Add(tool)
+
+	// Round 1: tool call (Session generates CompletionEnded internally)
+	mockClient := NewMultiRoundMockClient([][]StreamEvent{
+		{NewEventToolCall("call-1", "test-tool", `{"key": "value"}`)},
+		// Round 2: empty (session exits cleanly)
+		{},
+	})
+
+	ctx := context.Background()
+	events := chat.Session(ctx, mockClient)
+
+	var receivedEvents []StreamEvent
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for event := range events {
+			receivedEvents = append(receivedEvents, event)
+			if tc, ok := event.(EventToolCall); ok {
+				tc.Resolve(false)
+			}
+		}
+	}()
+
+	<-done
+
+	// Verify EventToolCallResolved was emitted
+	var resolvedEventFound bool
+	var resolvedEvent EventToolCallResolved
+	for _, event := range receivedEvents {
+		if r, ok := event.(EventToolCallResolved); ok {
+			resolvedEventFound = true
+			resolvedEvent = r
+			break
+		}
+	}
+
+	if !resolvedEventFound {
+		t.Error("Expected EventToolCallResolved to be emitted")
+	}
+
+	if resolvedEvent.CallID != "call-1" {
+		t.Errorf("Expected CallID 'call-1', got '%s'", resolvedEvent.CallID)
+	}
+
+	if resolvedEvent.Accepted {
+		t.Error("Expected Accepted to be false")
+	}
+}
+
+// TestSession_MultipleToolCalls_Events tests that multiple tool calls generate proper events
+func TestSession_MultipleToolCalls_Events(t *testing.T) {
+	chatTools := tools.NewTools()
+	chat := &Chat{
+		Messages: NewMessages(),
+		Tools:    chatTools,
+	}
+
+	tool1, err := tools.NewTool[map[string]string]("tool1", "Tool 1",
+		func(input map[string]string) (string, error) {
+			return "result1", nil
+		})
+	if err != nil {
+		t.Fatalf("Failed to create tool: %v", err)
+	}
+	tool2, err := tools.NewTool[map[string]string]("tool2", "Tool 2",
+		func(input map[string]string) (string, error) {
+			return "result2", nil
+		})
+	if err != nil {
+		t.Fatalf("Failed to create tool: %v", err)
+	}
+	chat.Tools.Add(tool1)
+	chat.Tools.Add(tool2)
+
+	// Round 1: two tool calls (Session generates CompletionEnded internally)
+	mockClient := NewMultiRoundMockClient([][]StreamEvent{
+		{
+			NewEventToolCall("call-1", "tool1", `{"param": "value1"}`),
+			NewEventToolCall("call-2", "tool2", `{"param": "value2"}`),
+		},
+		// Round 2: empty (session exits cleanly)
+		{},
+	})
+
+	ctx := context.Background()
+	events := chat.Session(ctx, mockClient)
+
+	var receivedEvents []StreamEvent
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for event := range events {
+			receivedEvents = append(receivedEvents, event)
+			if tc, ok := event.(EventToolCall); ok {
+				tc.Resolve(true)
+			}
+		}
+	}()
+
+	<-done
+
+	// Count events
+	var toolMessages []EventToolMessage
+	var resolvedEvents []EventToolCallResolved
+	for _, event := range receivedEvents {
+		if tm, ok := event.(EventToolMessage); ok {
+			toolMessages = append(toolMessages, tm)
+		}
+		if r, ok := event.(EventToolCallResolved); ok {
+			resolvedEvents = append(resolvedEvents, r)
+		}
+	}
+
+	// Should have 2 tool messages (one for each tool call)
+	if len(toolMessages) != 2 {
+		t.Errorf("Expected 2 EventToolMessage events, got %d", len(toolMessages))
+	}
+
+	// Should have 2 resolved events (one for each tool call)
+	if len(resolvedEvents) != 2 {
+		t.Errorf("Expected 2 EventToolCallResolved events, got %d", len(resolvedEvents))
+	}
+
+	// Verify tool messages
+	callIDs := make(map[string]bool)
+	for _, tm := range toolMessages {
+		callIDs[tm.CallID] = true
+		if !tm.Success {
+			t.Error("Expected all tool messages to have Success=true")
+		}
+	}
+	if len(callIDs) != 2 || !callIDs["call-1"] || !callIDs["call-2"] {
+		t.Error("Expected tool messages for both call-1 and call-2")
+	}
+
+	// Verify resolved events
+	resolvedCallIDs := make(map[string]bool)
+	for _, r := range resolvedEvents {
+		resolvedCallIDs[r.CallID] = r.Accepted
+	}
+	if len(resolvedCallIDs) != 2 || !resolvedCallIDs["call-1"] || !resolvedCallIDs["call-2"] {
+		t.Error("Expected resolved events for both call-1 and call-2, both accepted")
+	}
+}
+
+// TestSession_EventOrdering tests the correct ordering of events in the stream
+func TestSession_EventOrdering(t *testing.T) {
+	chatTools := tools.NewTools()
+	chat := &Chat{
+		Messages: NewMessages(),
+		Tools:    chatTools,
+	}
+
+	tool, err := tools.NewTool[map[string]string]("test-tool", "Test tool",
+		func(input map[string]string) (string, error) {
+			return "result", nil
+		})
+	if err != nil {
+		t.Fatalf("Failed to create tool: %v", err)
+	}
+	chat.Tools.Add(tool)
+
+	// Round 1: tool call (Session generates CompletionEnded internally)
+	mockClient := NewMultiRoundMockClient([][]StreamEvent{
+		{NewEventToolCall("call-1", "test-tool", `{"key": "value"}`)},
+		// Round 2: empty (session exits cleanly)
+		{},
+	})
+
+	ctx := context.Background()
+	events := chat.Session(ctx, mockClient)
+
+	var receivedEvents []StreamEvent
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for event := range events {
+			receivedEvents = append(receivedEvents, event)
+			if tc, ok := event.(EventToolCall); ok {
+				tc.Resolve(true)
+			}
+		}
+	}()
+
+	<-done
+
+	// Find positions of key events
+	var positions = make(map[string]int)
+	for i, event := range receivedEvents {
+		switch event.getType() {
+		case eventToolCall:
+			positions["toolCall"] = i
+		case eventToolCallResolved:
+			positions["resolved"] = i
+		case eventToolMessage:
+			positions["toolMessage"] = i
+		case eventCompletionEnded:
+			positions["completionEnded"] = i
+		}
+	}
+
+	// Verify ordering: toolCall < resolved < toolMessage < completionEnded
+	if pos, ok := positions["toolCall"]; ok {
+		if rPos, ok := positions["resolved"]; ok && pos >= rPos {
+			t.Errorf("ToolCall (%d) should come before ToolCallResolved (%d)", pos, rPos)
+		}
+		if tmPos, ok := positions["toolMessage"]; ok && pos >= tmPos {
+			t.Errorf("ToolCall (%d) should come before ToolMessage (%d)", pos, tmPos)
+		}
+		if cPos, ok := positions["completionEnded"]; ok && pos >= cPos {
+			t.Errorf("ToolCall (%d) should come before CompletionEnded (%d)", pos, cPos)
+		}
+	}
+
+	if rPos, ok := positions["resolved"]; ok {
+		if tmPos, ok := positions["toolMessage"]; ok && rPos >= tmPos {
+			t.Errorf("ToolCallResolved (%d) should come before ToolMessage (%d)", rPos, tmPos)
+		}
+		if cPos, ok := positions["completionEnded"]; ok && rPos >= cPos {
+			t.Errorf("ToolCallResolved (%d) should come before CompletionEnded (%d)", rPos, cPos)
+		}
+	}
+
+	if tmPos, ok := positions["toolMessage"]; ok {
+		if cPos, ok := positions["completionEnded"]; ok && tmPos >= cPos {
+			t.Errorf("ToolMessage (%d) should come before CompletionEnded (%d)", tmPos, cPos)
+		}
+	}
+}
+
+// TestSession_ToolMessageInHistory tests that tool messages are added to chat history
+func TestSession_ToolMessageInHistory(t *testing.T) {
+	chatTools := tools.NewTools()
+	chat := &Chat{
+		Messages: NewMessages(),
+		Tools:    chatTools,
+	}
+
+	tool, err := tools.NewTool[map[string]string]("test-tool", "Test tool",
+		func(input map[string]string) (string, error) {
+			return "history result", nil
+		})
+	if err != nil {
+		t.Fatalf("Failed to create tool: %v", err)
+	}
+	chat.Tools.Add(tool)
+
+	// Round 1: tool call (Session generates CompletionEnded internally)
+	mockClient := NewMultiRoundMockClient([][]StreamEvent{
+		{NewEventToolCall("call-1", "test-tool", `{"key": "value"}`)},
+		// Round 2: empty (session exits cleanly)
+		{},
+	})
+
+	ctx := context.Background()
+	events := chat.Session(ctx, mockClient)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for event := range events {
+			if tc, ok := event.(EventToolCall); ok {
+				tc.Resolve(true)
+			}
+		}
+	}()
+
+	<-done
+
+	// Check that tool message was added to history
+	messages := chat.Messages.Snapshot()
+	var toolMessageFound bool
+	for _, msg := range messages {
+		if tm, ok := msg.(EventToolMessage); ok {
+			toolMessageFound = true
+			if tm.CallID != "call-1" {
+				t.Errorf("Expected CallID 'call-1', got '%s'", tm.CallID)
+			}
+			if tm.Content != "history result" {
+				t.Errorf("Expected content 'history result', got '%s'", tm.Content)
+			}
+			if !tm.Success {
+				t.Error("Expected Success to be true")
+			}
+			break
+		}
+	}
+
+	if !toolMessageFound {
+		t.Error("Expected EventToolMessage to be added to history")
+	}
+}

--- a/chat/chat_test.go
+++ b/chat/chat_test.go
@@ -779,8 +779,7 @@ func TestHelpers_SendUserStream(t *testing.T) {
 	}
 
 	mockClient := NewMockClient()
-	mockClient.SetStreamingEvents([]StreamEvent{
-	})
+	mockClient.SetStreamingEvents([]StreamEvent{})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	events := chat.SendUserStream(ctx, mockClient, "User message")
@@ -810,8 +809,7 @@ func TestHelpers_SendAssistantStream(t *testing.T) {
 	}
 
 	mockClient := NewMockClient()
-	mockClient.SetStreamingEvents([]StreamEvent{
-	})
+	mockClient.SetStreamingEvents([]StreamEvent{})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	events := chat.SendAssistantStream(ctx, mockClient, "Assistant message")
@@ -841,8 +839,7 @@ func TestHelpers_SendSystemStream(t *testing.T) {
 	}
 
 	mockClient := NewMockClient()
-	mockClient.SetStreamingEvents([]StreamEvent{
-	})
+	mockClient.SetStreamingEvents([]StreamEvent{})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	events := chat.SendSystemStream(ctx, mockClient, "System message")

--- a/chat/events.go
+++ b/chat/events.go
@@ -212,6 +212,8 @@ type StreamEvent interface {
 	getType() eventType
 }
 
+// TODO: Remove deprecated types in v0.4
+
 // Deprecated: Use EventToken instead.
 type EventNewToken = EventToken
 

--- a/chat/events.go
+++ b/chat/events.go
@@ -13,6 +13,7 @@ const (
 
 	eventToken           eventType = "token"
 	eventToolCall        eventType = "tool_call"
+	eventToolCallToken   eventType = "tool_call_token"
 	eventRefusal         eventType = "refusal"
 	eventCompletionStart eventType = "completion_start"
 	eventCompletionEnded eventType = "completion_ended"
@@ -84,6 +85,21 @@ func (e EventToolCall) getType() eventType { return eventToolCall }
 // NewEventToolCall creates a new EventToolCall
 func NewEventToolCall(callID, name string, arguments string) EventToolCall {
 	return EventToolCall{EventBase: EventBase{Content: arguments}, CallID: callID, Name: name}
+}
+
+// EventToolCallToken represents a tool call token event
+// Used for streaming. Not supported by some providers
+type EventToolCallToken struct {
+	EventBase
+	CallID string `json:"call_id"`
+	Name   string `json:"name"`
+}
+
+func (e EventToolCallToken) getType() eventType { return eventToolCallToken }
+
+// NewEventToolCallToken creates a new EventToolCallToken
+func NewEventToolCallToken(callID, name string, token string) EventToolCallToken {
+	return EventToolCallToken{EventBase: EventBase{Content: token}, CallID: callID, Name: name}
 }
 
 // EventError represents an error event

--- a/chat/events.go
+++ b/chat/events.go
@@ -20,6 +20,7 @@ const (
 
 	// events produced by consumer
 
+	eventToolCallResolved eventType = "tool_call_resolved"
 	eventUserMessage      eventType = "user_message"
 	eventAssistantMessage eventType = "assistant_message"
 	eventSystemMessage    eventType = "system_message"
@@ -92,6 +93,18 @@ func (e EventToolCall) getType() eventType { return eventToolCall }
 // NewEventToolCall creates a new EventToolCall
 func NewEventToolCall(callID, name string, arguments string) EventToolCall {
 	return EventToolCall{EventBase: EventBase{Content: arguments}, CallID: callID, Name: name}
+}
+
+// EventToolCallResolved spawns when tool call is resolved by the user
+type EventToolCallResolved struct {
+	CallID   string `json:"call_id"`
+	Accepted bool   `json:"accepted"`
+}
+
+func (e EventToolCallResolved) getType() eventType { return eventToolCallResolved }
+
+func NewEventToolCallResolved(callID string, accepted bool) EventToolCallResolved {
+	return EventToolCallResolved{CallID: callID, Accepted: accepted}
 }
 
 // EventToolCallToken represents a tool call token event

--- a/chat/events.go
+++ b/chat/events.go
@@ -66,6 +66,8 @@ type EventToolCall struct {
 
 	approval *ApproveWaiter
 	answered bool
+
+	onResolved func(callID string, accepted bool)
 }
 
 func (e *EventToolCall) Resolve(accept bool) {
@@ -76,6 +78,11 @@ func (e *EventToolCall) Resolve(accept bool) {
 	if e.approval == nil {
 		return
 	}
+
+	if e.onResolved != nil {
+		e.onResolved(e.CallID, accept)
+	}
+
 	verdict := Verdict{Accepted: accept, call: *e}
 	e.approval.Resolve(verdict)
 }

--- a/chat/events.go
+++ b/chat/events.go
@@ -50,13 +50,14 @@ func NewEventCompletionStart() EventCompletionStart {
 
 // EventCompletionEnded represents a completion ended event
 // TODO: добавить finish_reason
-// TODO: добавить список вызовов инструментов
-type EventCompletionEnded struct{}
+type EventCompletionEnded struct {
+	ToolCalls []EventToolCall `json:"tool_calls,omitempty"`
+}
 
 func (e EventCompletionEnded) getType() eventType { return eventCompletionEnded }
 
-func NewEventCompletionEnded() EventCompletionEnded {
-	return EventCompletionEnded{}
+func NewEventCompletionEnded(toolCalls []EventToolCall) EventCompletionEnded {
+	return EventCompletionEnded{ToolCalls: toolCalls}
 }
 
 // EventToolCall represents a tool call event

--- a/chat/events.go
+++ b/chat/events.go
@@ -14,6 +14,7 @@ const (
 	eventToken           eventType = "token"
 	eventToolCall        eventType = "tool_call"
 	eventRefusal         eventType = "refusal"
+	eventCompletionStart eventType = "completion_start"
 	eventCompletionEnded eventType = "completion_ended"
 
 	// events produced by consumer
@@ -34,6 +35,15 @@ const (
 // EventBase is a base type for simple event types
 type EventBase struct {
 	Content string `json:"text"`
+}
+
+// EventCompletionStart represents a completion start event
+type EventCompletionStart struct{}
+
+func (e EventCompletionStart) getType() eventType { return eventCompletionStart }
+
+func NewEventCompletionStart() EventCompletionStart {
+	return EventCompletionStart{}
 }
 
 // EventCompletionEnded represents a completion ended event

--- a/chat/serial.go
+++ b/chat/serial.go
@@ -36,8 +36,12 @@ func UnmarshalEvent(data []byte) (StreamEvent, error) {
 		return unmarshalPayload[EventToken](env.Payload)
 	case eventToolCall:
 		return unmarshalPayload[EventToolCall](env.Payload)
+	case eventToolCallToken:
+		return unmarshalPayload[EventToolCallToken](env.Payload)
 	case eventRefusal:
 		return unmarshalPayload[EventRefusal](env.Payload)
+	case eventCompletionStart:
+		return unmarshalPayload[EventCompletionStart](env.Payload)
 	case eventCompletionEnded:
 		return unmarshalPayload[EventCompletionEnded](env.Payload)
 	case eventUserMessage:

--- a/chat/serial.go
+++ b/chat/serial.go
@@ -36,6 +36,8 @@ func UnmarshalEvent(data []byte) (StreamEvent, error) {
 		return unmarshalPayload[EventToken](env.Payload)
 	case eventToolCall:
 		return unmarshalPayload[EventToolCall](env.Payload)
+	case eventToolCallResolved:
+		return unmarshalPayload[EventToolCallResolved](env.Payload)
 	case eventToolCallToken:
 		return unmarshalPayload[EventToolCallToken](env.Payload)
 	case eventRefusal:

--- a/chat/serial_test.go
+++ b/chat/serial_test.go
@@ -107,7 +107,63 @@ func TestMarshalUnmarshalEvent_RoundTrip(t *testing.T) {
 				assert.Equal(t, "something went wrong", e.Error.Error())
 			},
 		},
-	}
+		{
+			name:  "EventCompletionStart",
+			event: NewEventCompletionStart(),
+			check: func(t *testing.T, result StreamEvent) {
+				_, ok := result.(EventCompletionStart)
+				require.True(t, ok)
+			},
+		},
+		{
+			name:  "EventToolCallToken",
+			event: NewEventToolCallToken("call-789", "stream_tool", `{"par`),
+			check: func(t *testing.T, result StreamEvent) {
+				e, ok := result.(EventToolCallToken)
+				require.True(t, ok)
+				assert.Equal(t, "call-789", e.CallID)
+				assert.Equal(t, "stream_tool", e.Name)
+				assert.Equal(t, `{"par`, e.Content)
+			},
+		},
+		{
+			name:  "EventToolCallResolved_Accepted",
+			event: NewEventToolCallResolved("call-123", true),
+			check: func(t *testing.T, result StreamEvent) {
+				e, ok := result.(EventToolCallResolved)
+				require.True(t, ok)
+				assert.Equal(t, "call-123", e.CallID)
+				assert.True(t, e.Accepted)
+			},
+		},
+		{
+			name:  "EventToolCallResolved_Rejected",
+			event: NewEventToolCallResolved("call-456", false),
+			check: func(t *testing.T, result StreamEvent) {
+				e, ok := result.(EventToolCallResolved)
+				require.True(t, ok)
+				assert.Equal(t, "call-456", e.CallID)
+				assert.False(t, e.Accepted)
+			},
+		},
+		{
+			name: "EventCompletionEnded_WithToolCalls",
+			event: NewEventCompletionEnded([]EventToolCall{
+				NewEventToolCall("call-1", "tool_a", `{"x":1}`),
+				NewEventToolCall("call-2", "tool_b", `{"y":2}`),
+			}),
+			check: func(t *testing.T, result StreamEvent) {
+				e, ok := result.(EventCompletionEnded)
+				require.True(t, ok)
+				require.Len(t, e.ToolCalls, 2)
+				assert.Equal(t, "call-1", e.ToolCalls[0].CallID)
+				assert.Equal(t, "tool_a", e.ToolCalls[0].Name)
+				assert.Equal(t, `{"x":1}`, e.ToolCalls[0].Content)
+				assert.Equal(t, "call-2", e.ToolCalls[1].CallID)
+				assert.Equal(t, "tool_b", e.ToolCalls[1].Name)
+				assert.Equal(t, `{"y":2}`, e.ToolCalls[1].Content)
+			},
+		}}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/chat/serial_test.go
+++ b/chat/serial_test.go
@@ -45,7 +45,7 @@ func TestMarshalUnmarshalEvent_RoundTrip(t *testing.T) {
 		},
 		{
 			name:  "EventCompletionEnded",
-			event: NewEventCompletionEnded(),
+			event: NewEventCompletionEnded(nil),
 			check: func(t *testing.T, result StreamEvent) {
 				_, ok := result.(EventCompletionEnded)
 				require.True(t, ok)


### PR DESCRIPTION
## Summary

Add missing stream events for completion lifecycle, tool call streaming and resolution,
and make tool execution results visible in the event stream.

## Feat: new events (#41)

- `EventCompletionStarted` — emitted at the start of each generation
- `EventToolCallToken` — streams tool call arguments token by token
- `EventToolCallResolved` — emitted when a tool call is approved or rejected

## Feat: collect tool calls in EventCompletionEnded (#47)

`EventCompletionEnded` now carries the list of all `EventToolCall` events from the current generation.
Now `EventCompletionEnded.ToolCalls` contains all tool calls from the generation.

## Feat: emit tool execution results to event stream (#46)

Tool execution results are now emitted as `EventToolMessage` — both on successful execution and on
user rejection.

Closes #41
Closes #46
Closes #47