### PR TITLE
Tool Call Improvements: hardcode removal, double resolution fix, configurable decline message

### DIFF
--- a/chat/chat.go
+++ b/chat/chat.go
@@ -7,6 +7,8 @@ import (
 	"github.com/x2d7/interlude/chat/tools"
 )
 
+const DefaultDeclinedToolMessage = "Tool call declined"
+
 func (c *Chat) Complete(ctx context.Context, client Client) <-chan StreamEvent {
 	result := make(chan StreamEvent, 16)
 
@@ -261,7 +263,11 @@ func (c *Chat) handleCompletionEnd(ctx context.Context, state *sessionState) (pr
 			callResult, success := c.Tools.Execute(call.Name, call.Content)
 			toolMessage = NewEventToolMessage(call.CallID, callResult, success)
 		} else {
-			toolMessage = NewEventToolMessage(call.CallID, "User declined the tool call", false)
+			msg := c.DeclinedToolMessage
+			if msg == "" {
+				msg = DefaultDeclinedToolMessage
+			}
+			toolMessage = NewEventToolMessage(call.CallID, msg, false)
 		}
 		// adding tool message to the chat
 		c.AppendEvent(toolMessage)

--- a/chat/chat_test.go
+++ b/chat/chat_test.go
@@ -651,7 +651,7 @@ func TestSession_ToolRejected(t *testing.T) {
 		if msg.getType() == eventToolMessage {
 			toolMsg := msg.(EventToolMessage)
 			if toolMsg.CallID == "call-1" && !toolMsg.Success &&
-				toolMsg.Content == "User declined the tool call" {
+				toolMsg.Content == DefaultDeclinedToolMessage {
 				rejectionFound = true
 			}
 		}
@@ -1653,7 +1653,7 @@ func TestSession_ToolMessageEmission_Rejection(t *testing.T) {
 		t.Errorf("Expected CallID 'call-1', got '%s'", toolMessage.CallID)
 	}
 
-	if toolMessage.Content != "User declined the tool call" {
+	if toolMessage.Content != DefaultDeclinedToolMessage {
 		t.Errorf("Expected rejection message, got '%s'", toolMessage.Content)
 	}
 

--- a/chat/chat_test.go
+++ b/chat/chat_test.go
@@ -6,9 +6,11 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/x2d7/interlude/chat/tools"
 )
 
@@ -2172,4 +2174,43 @@ func TestSession_ToolCallDuplicationIssue(t *testing.T) {
 			t.Errorf("Expected 1 tool message, got %d (possible double execution)", toolMessageCount)
 		}
 	})
+}
+
+func TestSession_ToolCall_DoubleResolveFromCopies(t *testing.T) {
+	c := &Chat{
+		Messages: NewMessages(),
+		Tools:    tools.NewTools(),
+	}
+
+	execCount := atomic.Int32{}
+	tool, _ := tools.NewTool[map[string]string]("test-tool", "Test tool",
+		func(input map[string]string) (string, error) {
+			execCount.Add(1)
+			return "result", nil
+		})
+	c.Tools.Add(tool)
+
+	mockClient := NewMultiRoundMockClient([][]StreamEvent{
+		{NewEventToolCall("call-1", "test-tool", `{"key": "value"}`)},
+		{},
+	})
+
+	ctx := context.Background()
+	events := c.Session(ctx, mockClient)
+
+	for event := range events {
+		switch e := event.(type) {
+		case EventToolCall:
+			err := e.Resolve(true)
+			assert.NoError(t, err)
+		case EventCompletionEnded:
+			if len(e.ToolCalls) > 0 {
+				// копия из EventCompletionEnded — уже резолвнута из стрима
+				err := e.ToolCalls[0].Resolve(true)
+				assert.ErrorIs(t, err, ErrAlreadyResolved)
+			}
+		}
+	}
+
+	assert.Equal(t, int32(1), execCount.Load(), "tool must be executed exactly once")
 }

--- a/chat/chat_test.go
+++ b/chat/chat_test.go
@@ -2102,3 +2102,74 @@ func TestSession_ToolMessageInHistory(t *testing.T) {
 		t.Error("Expected EventToolMessage to be added to history")
 	}
 }
+
+func TestSession_ToolCallDuplicationIssue(t *testing.T) {
+	chatTools := tools.NewTools()
+	ch := &Chat{
+		Messages: NewMessages(),
+		Tools:    chatTools,
+	}
+
+	tool, err := tools.NewTool[map[string]string]("test-tool", "Test tool",
+		func(input map[string]string) (string, error) {
+			return "result", nil
+		})
+	if err != nil {
+		t.Fatalf("Failed to create tool: %v", err)
+	}
+	ch.Tools.Add(tool)
+
+	mockClient := NewMultiRoundMockClient([][]StreamEvent{
+		{NewEventToolCall("call-1", "test-tool", `{"key": "value"}`)},
+		{},
+	})
+
+	ctx := context.Background()
+	events := ch.Session(ctx, mockClient)
+
+	var completionEndedEvent *EventCompletionEnded
+	var streamToolCalls []EventToolCall
+
+	// Consume events and resolve tool calls inline to avoid deadlock.
+	// Session blocks in approval.Wait() until verdicts arrive —
+	// so we must Resolve() before the channel can close.
+	for event := range events {
+		switch e := event.(type) {
+		case EventToolCall:
+			streamToolCalls = append(streamToolCalls, e)
+		case EventCompletionEnded:
+			ce := e
+			completionEndedEvent = &ce
+			// Resolve from EventCompletionEnded — first resolve, should fire
+			for _, tc := range ce.ToolCalls {
+				tc := tc
+				tc.Resolve(true)
+			}
+			// Resolve from stream copies — should be no-op due to answered flag
+			for _, tc := range streamToolCalls {
+				tc := tc
+				tc.Resolve(true)
+			}
+		}
+	}
+
+	if completionEndedEvent == nil {
+		t.Fatal("Expected EventCompletionEnded")
+	}
+	if len(streamToolCalls) == 0 {
+		t.Fatal("Expected EventToolCall from stream")
+	}
+
+	t.Run("verify_no_double_execution", func(t *testing.T) {
+		messages := ch.Messages.Snapshot()
+		toolMessageCount := 0
+		for _, msg := range messages {
+			if tm, ok := msg.(EventToolMessage); ok && tm.CallID == "call-1" {
+				toolMessageCount++
+			}
+		}
+		if toolMessageCount != 1 {
+			t.Errorf("Expected 1 tool message, got %d (possible double execution)", toolMessageCount)
+		}
+	})
+}

--- a/chat/errors.go
+++ b/chat/errors.go
@@ -6,4 +6,5 @@ var (
 	ErrUnsupportedSender        = errors.New("unsupported sender type")
 	ErrNilStreaming             = errors.New("streaming object is nil")
 	ErrAssistantMessageNotFound = errors.New("assistant message not found")
+	ErrAlreadyResolved          = errors.New("tool call already resolved")
 )

--- a/chat/events.go
+++ b/chat/events.go
@@ -72,17 +72,18 @@ type EventToolCall struct {
 	onResolved func(callID string, accepted bool)
 }
 
-func (e *EventToolCall) Resolve(accept bool) {
+func (e *EventToolCall) Resolve(accept bool) error {
 	if e.answered == nil || !e.answered.CompareAndSwap(false, true) {
-		return
+		return ErrAlreadyResolved
 	}
 	if e.approval == nil {
-		return
+		return nil
 	}
 	if e.onResolved != nil {
 		e.onResolved(e.CallID, accept)
 	}
 	e.approval.Resolve(Verdict{Accepted: accept, call: *e})
+	return nil
 }
 
 func (e EventToolCall) getType() eventType { return eventToolCall }

--- a/chat/events.go
+++ b/chat/events.go
@@ -3,6 +3,7 @@ package chat
 import (
 	"encoding/json"
 	"errors"
+	"sync/atomic"
 )
 
 // eventType represents the type of event
@@ -66,34 +67,34 @@ type EventToolCall struct {
 	CallID string `json:"call_id"`
 	Name   string `json:"name"`
 
-	approval *ApproveWaiter
-	answered bool
-
+	approval   *ApproveWaiter
+	answered   *atomic.Bool
 	onResolved func(callID string, accepted bool)
 }
 
 func (e *EventToolCall) Resolve(accept bool) {
-	if e.answered {
+	if e.answered == nil || !e.answered.CompareAndSwap(false, true) {
 		return
 	}
-	e.answered = true
 	if e.approval == nil {
 		return
 	}
-
 	if e.onResolved != nil {
 		e.onResolved(e.CallID, accept)
 	}
-
-	verdict := Verdict{Accepted: accept, call: *e}
-	e.approval.Resolve(verdict)
+	e.approval.Resolve(Verdict{Accepted: accept, call: *e})
 }
 
 func (e EventToolCall) getType() eventType { return eventToolCall }
 
 // NewEventToolCall creates a new EventToolCall
 func NewEventToolCall(callID, name string, arguments string) EventToolCall {
-	return EventToolCall{EventBase: EventBase{Content: arguments}, CallID: callID, Name: name}
+	return EventToolCall{
+		EventBase: EventBase{Content: arguments},
+		CallID:    callID,
+		Name:      name,
+		answered:  &atomic.Bool{},
+	}
 }
 
 // EventToolCallResolved spawns when tool call is resolved by the user

--- a/chat/events_test.go
+++ b/chat/events_test.go
@@ -1,0 +1,29 @@
+package chat
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEventToolCall_Resolve_ReturnsErrorOnDuplicate(t *testing.T) {
+	tc := NewEventToolCall("call-1", "test-tool", `{}`)
+
+	err := tc.Resolve(true)
+	assert.NoError(t, err)
+
+	err = tc.Resolve(true)
+	assert.ErrorIs(t, err, ErrAlreadyResolved)
+}
+
+func TestEventToolCall_Resolve_CopiesShareResolution(t *testing.T) {
+	tc := NewEventToolCall("call-1", "test-tool", `{}`)
+	copy1 := tc
+	copy2 := tc
+
+	err := copy1.Resolve(true)
+	assert.NoError(t, err)
+
+	err = copy2.Resolve(true)
+	assert.ErrorIs(t, err, ErrAlreadyResolved)
+}

--- a/chat/types.go
+++ b/chat/types.go
@@ -11,6 +11,8 @@ import (
 type Chat struct {
 	Messages *Messages
 	Tools    *tools.Tools
+
+	DeclinedToolMessage string // default: "Tool call declined"
 }
 
 // Client interface represents the LLM connector client


### PR DESCRIPTION
## Summary

Fix double resolution bug on `EventToolCall` copies, return error on duplicate Resolve, and make the declined tool message configurable.

## Fix: `EventToolCall` double resolution on copy (#51)

Fixed by replacing `answered bool` with `answered *atomic.Bool` — all copies of the same
tool call share the same atomic flag, so only the first `Resolve()` wins.

## Feat: return ErrAlreadyResolved on duplicate Resolve (#45)

`Resolve()` now returns `error` — `ErrAlreadyResolved` on duplicate call instead of silently doing nothing.

## Feat: configurable declined tool message (#42)

```go
type Chat struct {
	Messages *Messages
	Tools    *tools.Tools

	DeclinedToolMessage string // default: "Tool call declined"  <---- New field
}
```

Closes #42
Closes #45
Closes #51