### PR TITLE
Add EventReasoningMessage for reasoning content

### DIFF
--- a/chat/chat.go
+++ b/chat/chat.go
@@ -232,7 +232,7 @@ func (c *Chat) handleCompletionEnd(ctx context.Context, state *sessionState) (pr
 	proceed = false
 	// adding collected events to the chat (reasoning, assistant's tokens and tool calls)
 	if state.thinkingBuilder.Len() != 0 {
-		c.AppendEvent(NewEventAssistantMessage(state.thinkingBuilder.String()))
+		c.AppendEvent(NewEventReasoningMessage(state.thinkingBuilder.String()))
 	}
 	if state.builder.Len() != 0 {
 		c.AppendEvent(NewEventAssistantMessage(state.builder.String()))

--- a/chat/chat_test.go
+++ b/chat/chat_test.go
@@ -570,22 +570,21 @@ func TestSession_Thinking(t *testing.T) {
 
 	cancel()
 
-	// Check that thinking tokens were accumulated into assistant message
+	// Check that thinking tokens were accumulated into reasoning message
 	messages := chat.Messages.Snapshot()
 
-	var thinkingMsg, assistantMsg string
+	var reasoningMsg, assistantMsg string
 	for _, msg := range messages {
-		if am, ok := msg.(EventAssistantMessage); ok {
-			if thinkingMsg == "" {
-				thinkingMsg = am.Content
-			} else {
-				assistantMsg = am.Content
-			}
+		switch m := msg.(type) {
+		case EventReasoningMessage:
+			reasoningMsg = m.Content
+		case EventAssistantMessage:
+			assistantMsg = m.Content
 		}
 	}
 
-	if thinkingMsg != "let me think..." {
-		t.Errorf("Expected thinking message 'let me think...', got '%s'", thinkingMsg)
+	if reasoningMsg != "let me think..." {
+		t.Errorf("Expected reasoning message 'let me think...', got '%s'", reasoningMsg)
 	}
 
 	if assistantMsg != "answer" {

--- a/chat/chat_test.go
+++ b/chat/chat_test.go
@@ -603,7 +603,7 @@ func TestSession_ToolAccepted(t *testing.T) {
 	}
 
 	// Add a test tool
-	tool, err := tools.NewTool[map[string]string]("test-tool", "Test tool",
+	tool, err := tools.NewTool("test-tool", "Test tool",
 		func(input map[string]string) (string, error) {
 			return "success: " + input["key"], nil
 		})
@@ -659,7 +659,7 @@ func TestSession_ToolRejected(t *testing.T) {
 		Tools:    chatTools,
 	}
 
-	tool, err := tools.NewTool[map[string]string]("test-tool", "Test tool",
+	tool, err := tools.NewTool("test-tool", "Test tool",
 		func(input map[string]string) (string, error) {
 			return "should not be called", nil
 		})
@@ -994,7 +994,7 @@ func TestSession_ContextCancelledWhileWaitingForApproval(t *testing.T) {
 		Tools:    chatTools,
 	}
 
-	tool, err := tools.NewTool[map[string]string]("test-tool", "Test tool",
+	tool, err := tools.NewTool("test-tool", "Test tool",
 		func(input map[string]string) (string, error) {
 			return "result", nil
 		})
@@ -1051,7 +1051,7 @@ func TestSession_ContextCancelledBetweenRounds(t *testing.T) {
 		Tools:    chatTools,
 	}
 
-	tool, err := tools.NewTool[map[string]string]("test-tool", "Test tool",
+	tool, err := tools.NewTool("test-tool", "Test tool",
 		func(input map[string]string) (string, error) {
 			return "result", nil
 		})
@@ -1107,7 +1107,7 @@ func TestSession_ToolCallAssembly_Basic(t *testing.T) {
 		Tools:    chatTools,
 	}
 
-	tool, err := tools.NewTool[map[string]string]("weather", "Get weather",
+	tool, err := tools.NewTool("weather", "Get weather",
 		func(input map[string]string) (string, error) {
 			return "sunny", nil
 		})
@@ -1173,14 +1173,14 @@ func TestSession_ToolCallAssembly_MultipleToolsWithAssembly(t *testing.T) {
 		Tools:    chatTools,
 	}
 
-	tool1, err := tools.NewTool[map[string]string]("tool1", "Tool 1",
+	tool1, err := tools.NewTool("tool1", "Tool 1",
 		func(input map[string]string) (string, error) {
 			return "result1", nil
 		})
 	if err != nil {
 		t.Fatalf("Failed to create tool: %v", err)
 	}
-	tool2, err := tools.NewTool[map[string]string]("tool2", "Tool 2",
+	tool2, err := tools.NewTool("tool2", "Tool 2",
 		func(input map[string]string) (string, error) {
 			return "result2", nil
 		})
@@ -1268,7 +1268,7 @@ func TestSession_ToolCallAssembly_LargeContent(t *testing.T) {
 		Tools:    chatTools,
 	}
 
-	tool, err := tools.NewTool[map[string]string]("search", "Search",
+	tool, err := tools.NewTool("search", "Search",
 		func(input map[string]string) (string, error) {
 			return "results", nil
 		})
@@ -1343,7 +1343,7 @@ func TestSession_MixedTokensAndToolCalls(t *testing.T) {
 		Tools:    chatTools,
 	}
 
-	tool, err := tools.NewTool[map[string]string]("lookup", "Lookup tool",
+	tool, err := tools.NewTool("lookup", "Lookup tool",
 		func(input map[string]string) (string, error) {
 			return "ok", nil
 		})
@@ -1578,7 +1578,7 @@ func TestSession_ToolMessageEmission_Success(t *testing.T) {
 		Tools:    chatTools,
 	}
 
-	tool, err := tools.NewTool[map[string]string]("weather", "Get weather",
+	tool, err := tools.NewTool("weather", "Get weather",
 		func(input map[string]string) (string, error) {
 			return "sunny in Moscow", nil
 		})
@@ -1647,7 +1647,7 @@ func TestSession_ToolMessageEmission_Rejection(t *testing.T) {
 		Tools:    chatTools,
 	}
 
-	tool, err := tools.NewTool[map[string]string]("weather", "Get weather",
+	tool, err := tools.NewTool("weather", "Get weather",
 		func(input map[string]string) (string, error) {
 			return "sunny", nil
 		})
@@ -1716,7 +1716,7 @@ func TestSession_ToolMessageEmission_ExecutionError(t *testing.T) {
 		Tools:    chatTools,
 	}
 
-	tool, err := tools.NewTool[map[string]string]("failing-tool", "Failing tool",
+	tool, err := tools.NewTool("failing-tool", "Failing tool",
 		func(input map[string]string) (string, error) {
 			return "", errors.New("tool execution failed")
 		})
@@ -1785,7 +1785,7 @@ func TestSession_ToolCallResolvedEvent_Accept(t *testing.T) {
 		Tools:    chatTools,
 	}
 
-	tool, err := tools.NewTool[map[string]string]("test-tool", "Test tool",
+	tool, err := tools.NewTool("test-tool", "Test tool",
 		func(input map[string]string) (string, error) {
 			return "result", nil
 		})
@@ -1850,7 +1850,7 @@ func TestSession_ToolCallResolvedEvent_Reject(t *testing.T) {
 		Tools:    chatTools,
 	}
 
-	tool, err := tools.NewTool[map[string]string]("test-tool", "Test tool",
+	tool, err := tools.NewTool("test-tool", "Test tool",
 		func(input map[string]string) (string, error) {
 			return "result", nil
 		})
@@ -1915,14 +1915,14 @@ func TestSession_MultipleToolCalls_Events(t *testing.T) {
 		Tools:    chatTools,
 	}
 
-	tool1, err := tools.NewTool[map[string]string]("tool1", "Tool 1",
+	tool1, err := tools.NewTool("tool1", "Tool 1",
 		func(input map[string]string) (string, error) {
 			return "result1", nil
 		})
 	if err != nil {
 		t.Fatalf("Failed to create tool: %v", err)
 	}
-	tool2, err := tools.NewTool[map[string]string]("tool2", "Tool 2",
+	tool2, err := tools.NewTool("tool2", "Tool 2",
 		func(input map[string]string) (string, error) {
 			return "result2", nil
 		})
@@ -2011,7 +2011,7 @@ func TestSession_EventOrdering(t *testing.T) {
 		Tools:    chatTools,
 	}
 
-	tool, err := tools.NewTool[map[string]string]("test-tool", "Test tool",
+	tool, err := tools.NewTool("test-tool", "Test tool",
 		func(input map[string]string) (string, error) {
 			return "result", nil
 		})
@@ -2096,7 +2096,7 @@ func TestSession_ToolMessageInHistory(t *testing.T) {
 		Tools:    chatTools,
 	}
 
-	tool, err := tools.NewTool[map[string]string]("test-tool", "Test tool",
+	tool, err := tools.NewTool("test-tool", "Test tool",
 		func(input map[string]string) (string, error) {
 			return "history result", nil
 		})
@@ -2158,7 +2158,7 @@ func TestSession_ToolCallDuplicationIssue(t *testing.T) {
 		Tools:    chatTools,
 	}
 
-	tool, err := tools.NewTool[map[string]string]("test-tool", "Test tool",
+	tool, err := tools.NewTool("test-tool", "Test tool",
 		func(input map[string]string) (string, error) {
 			return "result", nil
 		})
@@ -2227,7 +2227,7 @@ func TestSession_ToolCall_DoubleResolveFromCopies(t *testing.T) {
 	}
 
 	execCount := atomic.Int32{}
-	tool, _ := tools.NewTool[map[string]string]("test-tool", "Test tool",
+	tool, _ := tools.NewTool("test-tool", "Test tool",
 		func(input map[string]string) (string, error) {
 			execCount.Add(1)
 			return "result", nil

--- a/chat/events.go
+++ b/chat/events.go
@@ -25,6 +25,7 @@ const (
 	eventToolCallResolved eventType = "tool_call_resolved"
 	eventUserMessage      eventType = "user_message"
 	eventAssistantMessage eventType = "assistant_message"
+	eventReasoningMessage eventType = "reasoning_message"
 	eventSystemMessage    eventType = "system_message"
 	eventToolMessage      eventType = "tool_message"
 
@@ -203,6 +204,18 @@ func (e EventAssistantMessage) getType() eventType { return eventAssistantMessag
 // NewEventAssistantMessage creates a new EventAssistantMessage
 func NewEventAssistantMessage(content string) EventAssistantMessage {
 	return EventAssistantMessage{EventBase: EventBase{Content: content}}
+}
+
+// EventReasoningMessage represents a reasoning message event (accumulated thinking content)
+type EventReasoningMessage struct {
+	EventBase
+}
+
+func (e EventReasoningMessage) getType() eventType { return eventReasoningMessage }
+
+// NewEventReasoningMessage creates a new EventReasoningMessage
+func NewEventReasoningMessage(content string) EventReasoningMessage {
+	return EventReasoningMessage{EventBase: EventBase{Content: content}}
 }
 
 // EventSystemMessage represents a system message event

--- a/chat/serial.go
+++ b/chat/serial.go
@@ -52,6 +52,8 @@ func UnmarshalEvent(data []byte) (StreamEvent, error) {
 		return unmarshalPayload[EventUserMessage](env.Payload)
 	case eventAssistantMessage:
 		return unmarshalPayload[EventAssistantMessage](env.Payload)
+	case eventReasoningMessage:
+		return unmarshalPayload[EventReasoningMessage](env.Payload)
 	case eventSystemMessage:
 		return unmarshalPayload[EventSystemMessage](env.Payload)
 	case eventToolMessage:

--- a/chat/serial_test.go
+++ b/chat/serial_test.go
@@ -33,6 +33,15 @@ func TestMarshalUnmarshalEvent_RoundTrip(t *testing.T) {
 			},
 		},
 		{
+			name:  "EventReasoningMessage",
+			event: NewEventReasoningMessage("reasoning content"),
+			check: func(t *testing.T, result StreamEvent) {
+				e, ok := result.(EventReasoningMessage)
+				require.True(t, ok)
+				assert.Equal(t, "reasoning content", e.Content)
+			},
+		},
+		{
 			name:  "EventToolCall",
 			event: NewEventToolCall("call-123", "my_tool", `{"key":"value"}`),
 			check: func(t *testing.T, result StreamEvent) {


### PR DESCRIPTION
Reasoning content is now stored as a dedicated `EventReasoningMessage` instead of `EventAssistantMessage`.